### PR TITLE
Enforce match limit not stream event limit

### DIFF
--- a/src/matches-list.js
+++ b/src/matches-list.js
@@ -23,7 +23,7 @@ function mapMatches(matches) {
     return matches.map(match => {
         return {
             match: match,
-            type: fs.stat(match).then(function (res) {
+            type: fs.stat(match).then(res => {
                 if (res.isFile()) {
                     return 'file';
                 } else if (res.isDirectory()) {
@@ -33,7 +33,7 @@ function mapMatches(matches) {
                 } else {
                     return 'other';
                 }
-            })
+            }).catch(err => 'other')
         };
     });
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -86,5 +86,5 @@ module.exports = { quit, getArrayFromBuffers, executeAction };
 
 // NON-EXPORTED
 async function writeToClipboard(text) {
-    return clipboardy.write(text);
+    return clipboardy.write(_.trimEnd(text));
 }


### PR DESCRIPTION
- Handle case where no results
- Trim trailing whitespace on copy
- Catch fs.stat errors; assume type 'other'
- Set max matches limit to 1000